### PR TITLE
Add Developer Mode guide to Device Guides

### DIFF
--- a/docs/guides/device/controller-features.md
+++ b/docs/guides/device/controller-features.md
@@ -2,7 +2,7 @@
 id: controller-features
 title: Controller Hardware and Features
 description: An overview of the controller's buttons and sensors, touchpad gestures, and important changes from the Magic Leap 1 SDK.
-sidebar_position: 1
+sidebar_position: 2
 date: 1/28/2022
 tags: [Controller, Input, Power, Power Off, Shut Down]
 keywords: [ontroller, Input, Power, Power Off, Shut Down]

--- a/docs/guides/device/developer-mode.md
+++ b/docs/guides/device/developer-mode.md
@@ -1,0 +1,29 @@
+---
+id: developer-mode
+title: Developer Mode
+sidebar_position: 0
+description: Instructions for enabling Developer Mode on device
+date: 02/01/2023
+tags: [Unity, Native, Developer Mode, development, OS Update]
+keywords: [Unity, Native, Developer Mode, development, OS Update]
+---
+
+# Developer Mode
+
+In order to update the OS, view custom spatial anchors in the Spaces application, and build and deploy your own applications to the Magic Leap 2 headset, you must enable Developer Mode inside the Settings application.
+
+## How to enable Developer Mode
+
+1. Inside the headset, open the **Settings** application.
+
+![Setting app in the OS menu](/img/developer-mode/settings.jpg)
+
+2. Go to **About**
+
+![About section in Settings](/img/developer-mode/about.jpg)
+
+3. Scroll down to find the **Build Number**
+
+![Build Number section in About](/img/developer-mode/buildnumber.jpg)
+
+4. Hover over the Build Number and squeeze the trigger 7 times. You will get a confirmation message that the device is now in Developer Mode.

--- a/docs/guides/device/updating-the-os/_category_.json
+++ b/docs/guides/device/updating-the-os/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Updating the OS",
-  "position": 0,
+  "position": 1,
   "collapsed": true
 }

--- a/static/img/developer-mode/about.jpg
+++ b/static/img/developer-mode/about.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82652bd35b57bf96c1d19f6b66bdcc967aca17d608db8b493bdf66b66864f19c
+size 190120

--- a/static/img/developer-mode/buildnumber.jpg
+++ b/static/img/developer-mode/buildnumber.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a18d6942cf80b9eaa995f08dbd0f8de9c4115f01e5c56e370e97f6386788175e
+size 156953

--- a/static/img/developer-mode/settings.jpg
+++ b/static/img/developer-mode/settings.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acdb3748e65bbfa7ce4209ba0440f0b53b3e24999edcd9002dcedbe16c756089
+size 161671


### PR DESCRIPTION
Short documentation with screenshots showing the user how to enable Developer Mode on OS version 1.1.0 or later.