### PR TITLE
docs: adding security labels to arcloud namespace instructions

### DIFF
--- a/docs/guides/arcloud/_install_arcloud.md
+++ b/docs/guides/arcloud/_install_arcloud.md
@@ -25,6 +25,7 @@ cat ./setup/certificate.yaml | envsubst | kubectl -n istio-system apply -f -
 ```shell showLineNumbers
 kubectl create namespace ${NAMESPACE}
 kubectl label namespace ${NAMESPACE} istio-injection=enabled
+kubectl label namespace ${NAMESPACE} pod-security.kubernetes.io/audit=baseline pod-security.kubernetes.io/audit-version=v1.25 pod-security.kubernetes.io/warn=baseline pod-security.kubernetes.io/warn-version=v1.25
 ```
 
 ### Create Container Registry Secret


### PR DESCRIPTION
Adding additional kubernetes security labels to the arcloud namespace refer to [ARCLOUD-1146](https://magicleap.atlassian.net/browse/ARCLOUD-1146)