### PR TITLE
Add Google Tag Manager to Developer Portal

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,6 +262,9 @@ module.exports = {
     [
       '@docusaurus/preset-classic',
       {
+        googleTagManager: {
+          containerId: 'GTM-KPZG3CL',
+        },
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // We do not want any 'Edit this page' links


### PR DESCRIPTION
* Add Google Tag Manager containerId to docusaurus config file to enable Google Tag Manager functionality