### PR TITLE
Add Magic Leap transparency statement to Eye Tracking API pages

### DIFF
--- a/docs/guides/features/eye-tracking/eye-calibration.md
+++ b/docs/guides/features/eye-tracking/eye-calibration.md
@@ -11,6 +11,10 @@ keywords: [Eyes, Calibration, Eye Calibration, Fit, Design guidelines, Best Prac
 
 Developers can use the Eye Calibration API to determine the current status of the eye calibration system.
 
+:::note
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the Magic Leap 2 Eye Tracking Data Transparency Policy.
+:::
+
 ## The Eye Calibration API returns one of three outputs
 
 - **Fine** - eye-tracking is precise enough to use as input for selecting buttons or icons.

--- a/docs/guides/features/eye-tracking/eye-calibration.md
+++ b/docs/guides/features/eye-tracking/eye-calibration.md
@@ -12,7 +12,7 @@ keywords: [Eyes, Calibration, Eye Calibration, Fit, Design guidelines, Best Prac
 Developers can use the Eye Calibration API to determine the current status of the eye calibration system.
 
 :::note
-If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the Magic Leap 2 Eye Tracking Data Transparency Policy.
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the [Magic Leap 2 Eye Tracking Data Transparency Policy](https://www.magicleap.com/eye-tracking).
 :::
 
 ## The Eye Calibration API returns one of three outputs

--- a/docs/guides/features/eye-tracking/eye-tracking.md
+++ b/docs/guides/features/eye-tracking/eye-tracking.md
@@ -18,7 +18,7 @@ Eye tracking on Magic Leap 2 lets developers design natural and intuitive input 
 The predicted eye-gaze is approximately within 1 degree in visual angle around the actual target. Slight imprecisions are expected, so developers should plan for some margin around this lower-bound value.  
 
 :::note
-If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the Magic Leap 2 Eye Tracking Data Transparency Policy.
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the [Magic Leap 2 Eye Tracking Data Transparency Policy](https://www.magicleap.com/eye-tracking).
 :::
 
 

--- a/docs/guides/features/eye-tracking/eye-tracking.md
+++ b/docs/guides/features/eye-tracking/eye-tracking.md
@@ -17,6 +17,10 @@ Eye tracking on Magic Leap 2 lets developers design natural and intuitive input 
 
 The predicted eye-gaze is approximately within 1 degree in visual angle around the actual target. Slight imprecisions are expected, so developers should plan for some margin around this lower-bound value.  
 
+:::note
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the Magic Leap 2 Eye Tracking Data Transparency Policy.
+:::
+
 
 ## More Information
 

--- a/docs/guides/unity/input/eye-tracking/eye-tracking-api-overview.md
+++ b/docs/guides/unity/input/eye-tracking/eye-tracking-api-overview.md
@@ -16,6 +16,10 @@ Magic Leap's Eye Tracking data is retrieved in two ways.
 
 Regardless of which data you access, you must initialize the Magic Leap Eye tracking service first.
 
+:::note
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the [Magic Leap 2 Eye Tracking Data Transparency Policy](https://www.magicleap.com/eye-tracking).
+:::
+
 ## Initialize Eye Tracking
 
 :::caution

--- a/docs/guides/unity/input/eye-tracking/eye-tracking-overview.md
+++ b/docs/guides/unity/input/eye-tracking/eye-tracking-overview.md
@@ -9,6 +9,10 @@ keywords: [Unity, Eye Tracking, Input, Overview]
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
+:::note
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the [Magic Leap 2 Eye Tracking Data Transparency Policy](https://www.magicleap.com/eye-tracking).
+:::
+
 Eye tracking uses cameras to track the movement of the user’s eyes to  calculate where a user is looking, track whether they are blinking, and check if their eyes are in a comfortable configuration.
 
 :::caution

--- a/docs/guides/unity/input/eye-tracking/eye-tracking-porting-guide.md
+++ b/docs/guides/unity/input/eye-tracking/eye-tracking-porting-guide.md
@@ -14,6 +14,10 @@ import TabItem from '@theme/TabItem';
 
 The Magic Leap 2's eye tracking input can largely be accessed using Unity's [Input System](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/manual/QuickStartGuide.html). However, some platform specific values are accessed via the `TrackingState`, which can be retrieved using Magic Leaps `InputSubsystem.Extensions`.
 
+:::note
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the [Magic Leap 2 Eye Tracking Data Transparency Policy](https://www.magicleap.com/eye-tracking).
+:::
+
 When upgrading an ML1 app please note:
 
 - The `MLEyesStarterKit` class has been removed

--- a/docs/guides/unity/input/eye-tracking/eye-tracking-subsystem-extension.md
+++ b/docs/guides/unity/input/eye-tracking/eye-tracking-subsystem-extension.md
@@ -10,6 +10,10 @@ keywords: [Unity, Eye Tracking, Input, Porting]
 # Magic Leap Eye Tracking Data
 To obtain Magic Leap device specific features such as checking the eye tracking FixationConfidence status or if the user is blinking use Magic Leap's [InputSubsystem.Extensions](/unity-api/api/UnityEngine.XR.MagicLeap/InputSubsystem/Extensions/MLEyes/UnityEngine.XR.MagicLeap.InputSubsystem.Extensions.MLEyes.md)
 
+:::note
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the [Magic Leap 2 Eye Tracking Data Transparency Policy](https://www.magicleap.com/eye-tracking).
+:::
+
 Below is a list of some of the data that can be obtained via the [`EyeTrackingState`](/unity-api/api/UnityEngine.XR.MagicLeap/InputSubsystem/Extensions/MLEyes/UnityEngine.XR.MagicLeap.InputSubsystem.Extensions.MLEyes.State.md).
 
 - Fixation Confidence

--- a/docs/guides/unity/input/eye-tracking/tracked-pose-driver-eye-tracking.md
+++ b/docs/guides/unity/input/eye-tracking/tracked-pose-driver-eye-tracking.md
@@ -7,6 +7,9 @@ tags: [Unity, Eye Tracking, Input]
 keywords: [Unity, Eye Tracking, Input]
 ---
 
+:::note
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the [Magic Leap 2 Eye Tracking Data Transparency Policy](https://www.magicleap.com/eye-tracking).
+:::
 
 In addition to getting the eye center and fixation point transforms in code via the `UnityEngine.InputSystem.XR.Eyes` struct, you can also use the `TrackedPoseDriver` component, as long as it has been configured with the appropriate input action bindings.
 

--- a/docs/guides/unity/input/eye-tracking/unity-input-system-eye-tracking-input.md
+++ b/docs/guides/unity/input/eye-tracking/unity-input-system-eye-tracking-input.md
@@ -9,6 +9,10 @@ keywords: [Unity, Eye Tracking, Input, Porting]
 
 # Generic Eye Tracking Data
 
+:::note
+If your Application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, then you must comply with the [Magic Leap 2 Eye Tracking Data Transparency Policy](https://www.magicleap.com/eye-tracking).
+:::
+
 Unity Input System can be used to obtain common eye tracking input such as the user's Fixation Point. This section includes a few examples of accessing eye tracking data through the EyesAction class.
 
 See Unity's [UnityEngine.InputSystem.XR.Eyes](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/api/UnityEngine.InputSystem.XR.Eyes.html) API section for information on all the type of data that can be obtained.


### PR DESCRIPTION
* Add note to Eye Tracking API pages stipulating if an application collects, stores, transfers or otherwise uses data off the Magic Leap 2 device that is received via this API, the application must comply with the Magic Leap 2 Eye Tracking Data Transparency Policy at https://www.magicleap.com/eye-tracking.