### PR TITLE
Remove autoplay from App Sim video

### DIFF
--- a/docs/guides/developer-tools/app-sim/app-simulator.md
+++ b/docs/guides/developer-tools/app-sim/app-simulator.md
@@ -9,7 +9,7 @@ keywords: [Application Simulator]
 ---
 import ReactPlayer from 'react-player'
 
-<ReactPlayer playing controls url='/videos/AppSimOverview_V2_2.mp4' />  
+<ReactPlayer controls url='/videos/AppSimOverview_V2_2.mp4' />  
 
 <br/>
 The Application Simulator tool in the ML Hub lets you iterate and test code changes without having to build and deploy the app to a device. Incorporating Application Simulator into your workflow can result in significantly faster development cycles.


### PR DESCRIPTION
* Remove the autoplay functionality from the video at the top of the App Sim Overview page under Developer Tools