### PR TITLE
Made minor updates to Unity and Native project setup guides

### DIFF
--- a/docs/guides/native/getting-started/command-line-workflow.md
+++ b/docs/guides/native/getting-started/command-line-workflow.md
@@ -41,7 +41,7 @@ After opening your preferred command line interface (CLI), you must set up the *
 ```shell
 set ANDROID_HOME=%USERPROFILE%\AppData\Local\Android\sdk
 
-set MLSDK=%USERPROFILE%\MagicLeap\mlsdk\<mlsdk_folder_name>
+set MLSDK=%USERPROFILE%\MagicLeap\mlsdk\<mlsdk_version>
 
 set JAVA_HOME=%USERPROFILE%\jdk-11
 ```
@@ -50,9 +50,9 @@ set JAVA_HOME=%USERPROFILE%\jdk-11
  <TabItem value="mac" label="MacOS">
 
 ```shell
-export ANDROID_HOME=$USER/AppData/Local/Android/sdk
+export ANDROID_HOME=~/Library/Android/sdk
 
-export MLSDK=$USER/MagicLeap/mlsdk/<mlsdk_folder_name>
+export MLSDK=~/MagicLeap/mlsdk/<mlsdk_version>
 
 export JAVA_HOME=$USER/jdk-11
 ```
@@ -78,6 +78,7 @@ The `JAVA_HOME` value may be different, verify its location by running
 - All build.py scripts by default build both release and debug apps. If you only wish to build debug apps use `--config debug`. If you wish to build release apps `--config release`.
 - Make sure that that `app_framework` and apps are built for the same config (debug vs release).
 
+Python build scripts are available for the C-API samples as well as the application framework upon which they are built. To run a full clean build using any of the build scripts you can use the following command-
 
 <Tabs groupId="operating-systems">
   <TabItem value="win" label="Windows">
@@ -108,7 +109,7 @@ python3 build.py --clean
 </Tabs>
 
 :::info
-If you receive errors that the `Vulkan_LIBRARY` is missing, make sure you have [Vulkan](https://www.lunarg.com/vulkan-sdk/) installed on your machine.
+If you receive errors that the `Vulkan_LIBRARY` is missing, make sure you have the [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/) installed on your machine.
 :::
 
 ## Building the Application Framework

--- a/docs/guides/native/getting-started/native-setup-overview.md
+++ b/docs/guides/native/getting-started/native-setup-overview.md
@@ -14,13 +14,15 @@ There are two main ways of building Native applications, a [command line workflo
 
 ## Prerequisites
 
-1. Install the *Electric Eel* version of [Android Studio](https://developer.android.com/studio/archive).
+1. Install the latest version of the [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/).
+
+2. Install the latest *Electric Eel* version of [Android Studio](https://developer.android.com/studio/archive). (2022.1.1 Patch 2 at time of writing)
 
 :::note
-Make sure you have installed Android SDK Tools 31, Android SDK Command Line, and Android SDK Platform Tools in Android Studio if they did not automatically download.
+Make sure you have installed the Android SDK Tools, Android SDK Command Line, and Android SDK Platform Tools in Android Studio if they did not automatically download.
 :::
 
-2. Open the SDK Manager
+3. Open the SDK Manager
 
 You can find the SDK Manager by either selecting **More Actions** on the landing screen, or from the **Tools** dropdown from within a project.
 
@@ -28,11 +30,11 @@ You can find the SDK Manager by either selecting **More Actions** on the landing
 
 ![SDK Manager Option in Tools Dropdown](/img/migration-images/a_showSDK.png)
 
-3. Install [Android SDK 10 (Q) API Level 29](https://developer.android.com/about/versions/10/setup-sdk) under **SDK Platforms**.
+4. Install [Android SDK 10 (Q) API Level 29](https://developer.android.com/about/versions/10/setup-sdk) under **SDK Platforms**.
 
 ![Android SDK option in Android Studio](/img/migration-images/b_showSDK.png)
 
-4. Install [Android NDK](https://developer.android.com/ndk) *version 25.0.8775105* under **SDK Tools**.
+5. Install [Android NDK](https://developer.android.com/ndk) *version 25.0.8775105* under **SDK Tools**.
 
 :::tip
 If you don't see different version options, check **Show Package Details** at the bottom right.
@@ -40,13 +42,9 @@ If you don't see different version options, check **Show Package Details** at th
 
 ![Android NDK option in Android Studio](/img/migration-images/c_showNDK.png)
 
-5. Install [Cmake](https://cmake.org/) *version 3.22.1* under **SDK Tools**.
+6. Install [Cmake](https://cmake.org/) *version 3.22.1* under **SDK Tools**.
 
 ![CMake Option in Android Studio](/img/migration-images/d_showCmake.png)
-
-:::note
-If you don't already have [Vulkan](https://www.lunarg.com/vulkan-sdk/) installed, you'll need that as well.
-:::
 
 :::note
 You may need to install Ninja if you are getting errors that CMake can't find it:

--- a/docs/guides/unity/app-simulator/configure-unity.md
+++ b/docs/guides/unity/app-simulator/configure-unity.md
@@ -12,7 +12,7 @@ You will need to configure a few Unity Settings for the simulator to run properl
 
 The Magic Leap SDK Path setting will only show once the Magic Leap XR package is imported. If the Magic Leap SDK path setting is not visible, make sure that the `com.magicleap.xr` package was correctly imported.
 
-1. Open **Edit > Preferences** on Windows (or macOS: **Unity > Preferences**), then navigate to **External Tools > Magic Leap**.
+1. Open **Edit > Preferences** on Windows (or macOS: **Unity > Settings**), then navigate to **External Tools > Magic Leap**.
 
 - Set the MLSDK path to the Magic Leap SDK you downloaded from the ML Hub earlier. For example:
   - Mac: `$HOME/MagicLeap/mlsdk/<Version>/`
@@ -30,7 +30,7 @@ The Magic Leap XR Provider needs to be enabled before using Magic Leap's platfor
 
 1. Go to **File > Build Settings > Player Settings > XR Plug-in Management** and enable **Magic Leap** as a Plug-in Provider on the **Android** platform.
 
-2. In the **Standalone** tab, select **Magic Leap App Simulator** (formerly known as Zero Iteration). This step is required for App Simulator to run properly.
+2. In the **Windows, Mac, Linux settings** tab, select **Magic Leap App Simulator** (formerly known as Zero Iteration). This step is required for App Simulator to run properly.
 
 :::note
 If you are having any issues applying these changes, restart the Unity Editor. An editor restart may also be required for App Simulator to run correctly.

--- a/docs/guides/unity/getting-started/unity-building-simple-app.md
+++ b/docs/guides/unity/getting-started/unity-building-simple-app.md
@@ -46,7 +46,7 @@ When you are ready to deploy your application to the device, you can use the **B
 1. Connect and power on the device.
 2. Open the Build Settings, **File > Build Settings**.
 3. Add your current scene by dragging the scene from the Project panel to the **Scenes in Build** or clicking on **Add Open Scenes**.
-4. If you have more one than one scene in the list, uncheck all except the one you want to build.
+4. If you have more than one scene in the list, uncheck all except the one you want to build.
 5. Press **Build And Run** and select a location and name for the application (.apk)
 6. Wait for Unity to deploy the application.
 7. Put on the device and look around to find the cube.

--- a/docs/guides/unity/input/hand-tracking/unity-hand-tracking-overview.md
+++ b/docs/guides/unity/input/hand-tracking/unity-hand-tracking-overview.md
@@ -20,7 +20,7 @@ using UnityEngine.XR.MagicLeap;
 
 ## Requirements
 
-Hand Tracking Requires developers to enable the Hand Tracking permissions in the Manifest Settings. To do this Go to **Edit > Project Settings > Magic Leap > Manifest Settings** and enable `Hand_Tracking`. For more information, refer to the [permissions guide](/docs/guides/unity/permissions/declaring-permissions.md).
+Hand Tracking Requires developers to enable the Hand Tracking permissions in the Manifest Settings. To do this Go to **Edit > Project Settings > Magic Leap > Permissions** and enable `com.magicleap.permission.HAND_TRACKING`. For more information, refer to the [permissions guide](/docs/guides/unity/permissions/declaring-permissions.md).
 
 ## See Also
 


### PR DESCRIPTION
I tried going through the native and Unity setup guides. Putting out a pr for some minor edits I came across as I went through them.

Edits are in the following guides-
Command Line Workflow - fixed sdk paths for MacOS in "Set up Environment Variables"
Configure Unity - updated a couple names to reflect what appears in Unity 2022.2 on MacOS
Native Setup Overview - reword to clarify that the Vulkan SDK from LunarG needs to be installed
Unity Building Simple App - typo
Unity Hand Tracking Overview - Update labels to reflect how the permissions settings page currently appears