### PR TITLE
Remote Render Unreal 5 Alpha Settings

### DIFF
--- a/docs/guides/remote-render/unreal-engine-5.md
+++ b/docs/guides/remote-render/unreal-engine-5.md
@@ -78,7 +78,7 @@ Go to **Window** and enable the **Content Browser**. From the **Content Browser*
 
 ![Content Browser New Material](/img/unreal-5/alpha-channel/content-browser-new-material.png)
 
-The newly-created material must first be setup as a post-processing material with alpha support.
+The newly-created material must first be set up as a post-processing material with alpha support.
 
 In the **Content Browser**, open the **Material Editor** by right-clicking on the material and selecting **Edit**.
 
@@ -103,6 +103,7 @@ Add a **PostProcessVolume** actor in your level, enable `Infinite Extent (Unboun
 
 ![Level Post-Process Volume](/img/unreal-5/alpha-channel/level-post-process-volume.png)
 ![Post-Process Volume Infinite Extent](/img/unreal-5/alpha-channel/post-process-volume-infinite-extent.png)
+![Level Post-Process Volume 2](/img/unreal-5/alpha-channel/material-graph-post-process-material-2.png)
 
 ## VR Preview
 

--- a/docs/guides/remote-render/unreal-engine-5.md
+++ b/docs/guides/remote-render/unreal-engine-5.md
@@ -60,13 +60,13 @@ Vulkan is the main supported graphics API for Magic Remote Rendering. Support fo
 
 ### Alpha Channel in Unreal Engine 5
 
-Magic Leap's remote rendering now supports alpha channels, which provides the user with segmented dimming and higher quality capture.
+Magic Leap's Remote Render now supports alpha channels, which provides the user with segmented dimming and higher quality capture.
 
 In order to take advantage of this feature in Unreal Engine OpenXR applications, you must first enable and control the output of the alpha channel.
 
 First, you must prepare the application by allowing the engine to output alpha for postprocessing in the first place.
 
-Go to **Project Settings** -> **Rendering** -> **Postprocessing** and set `Enable alpha channel support in post processing` to `Allow through tonemapper`.
+Go to **Project Settings** -> **Rendering** -> **Postprocessing** and set **Enable alpha channel support in post processing** to `Allow through tonemapper`.
 
 ![Enable Alpha Channel in Post-Processing](/img/unreal-5/alpha-channel/enable-alpha-channel-post-processing.png)
 

--- a/docs/guides/remote-render/unreal-engine-5.md
+++ b/docs/guides/remote-render/unreal-engine-5.md
@@ -43,7 +43,7 @@ If you’re using the Virtual Reality template in Step 1, this step will not be 
 
 ![Project Settings VR](/img/unreal-5/preoject-settings-vr.png)
 
-1. Set the **RHI** to `Vulkan`
+2. Set the **RHI** to `Vulkan`
 
 Under **Edit** -> **Project Settings**:
 
@@ -52,14 +52,60 @@ Under **Edit** -> **Project Settings**:
 
 ![Project Settings Platform Windows RHI](/img/unreal-5/project-settings-platform-windows.png)
 
-1. Click <kbd>Restart Now</kbd>
+3. Click <kbd>Restart Now</kbd>
 
 :::note
 Vulkan is the main supported graphics API for Magic Remote Rendering. Support for DirectX 11 and DirectX 12 are considered as experimental.
 :::
 
+### Alpha Channel in Unreal Engine 5
+
+Magic Leap's remote rendering now supports alpha channels, which provides the user with segmented dimming and higher quality capture.
+
+In order to take advantage of this feature in Unreal Engine OpenXR applications, you must first enable and control the output of the alpha channel.
+
+First, you must prepare the application by allowing the engine to output alpha for postprocessing in the first place.
+
+Go to **Project Settings** -> **Rendering** -> **Postprocessing** and set `Enable alpha channel support in post processing` to `Allow through tonemapper`.
+
+![Enable Alpha Channel in Post-Processing](/img/unreal-5/alpha-channel/enable-alpha-channel-post-processing.png)
+
+The alpha channel as exposed by Unreal Engine will not be enough for alpha blend layers in OpenXR, this is entirely due to the fact that the alpha output is inverted.
+
+In order to correct this you will have to create a post-processing material that inverts the value of the alpha channel before it's submitted to the Remote Renderer.
+
+Go to **Window** and enable the **Content Browser**. From the **Content Browser**, add a new material in the desired directory.
+
+![Content Browser New Material](/img/unreal-5/alpha-channel/content-browser-new-material.png)
+
+The newly-created material must first be setup as a post-processing material with alpha support.
+
+In the **Content Browser**, open the **Material Editor** by right-clicking on the material and selecting **Edit**.
+
+Select the material in the **Material Graph** and under **Material** category set **Material Domain** to `Post Process`, then under the **Post Process Material** category enable `Output Alpha`.
+
+![Material Graph Post-Process Material](/img/unreal-5/alpha-channel/material-graph-post-process-material.png)
+![Material Graph Post-Process Material Output Alpha](/img/unreal-5/alpha-channel/material-graph-output-alpha.png)
+
+Now you may proceed to creating the material, in this example alpha is being inverted directly from the post-processing input.
+
+Add a new **SceneTexture** node and set **Scene Texture Id** to `PostProcessInput0`. This will be the main color input the material that will be worked on.
+
+![Material Graph Scene Texture Node](/img/unreal-5/alpha-channel/material-graph-new-scene-texture.png)
+
+The RGB channels will not be changing at all, so connect **SceneTexture.PostProcessInput0:Color** output to your material's **Emissive Color** input.
+
+Add a **ComponentMask** node and a **OneMinus** node, then pipeline **SceneTexture.PostProcessInput0:Color** output through the **ComponentMask** node (set to `Alpha` only), then the **OneMinus** node, and finally into the material's **Opacity** input.
+
+![Material Graph OneMinus](/img/unreal-5/alpha-channel/material-graph-component-mask-one-minus.png)
+
+Add a **PostProcessVolume** actor in your level, enable `Infinite Extent (Unbound)` under its Post **Process Volume Settings** properties and add your material to **Post Process Materials** under **Rendering Features**.
+
+![Level Post-Process Volume](/img/unreal-5/alpha-channel/level-post-process-volume.png)
+![Post-Process Volume Infinite Extent](/img/unreal-5/alpha-channel/post-process-volume-infinite-extent.png)
+
 ## VR Preview
 
-Once the editor has been restarted and shader compilation finishes, simply click `VR Preview`.
+Once the editor has been restarted and shader compilation finishes, simply click <kbd>**VR Preview**</kbd>.
 
 ![VR Preview](/img/unreal-5/editor-vr-preview.png)

--- a/static/img/unreal-5/alpha-channel/content-browser-new-material.png
+++ b/static/img/unreal-5/alpha-channel/content-browser-new-material.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bf1c9c281797ac4f88426b7eddd035242a5b64bfb44e5c310cdf95e2b561aa3
+size 610255

--- a/static/img/unreal-5/alpha-channel/enable-alpha-channel-post-processing.png
+++ b/static/img/unreal-5/alpha-channel/enable-alpha-channel-post-processing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc79a29ddbb162d77da73abf1930194045a8270616151d2c5f1233c544c25ef1
+size 97943

--- a/static/img/unreal-5/alpha-channel/level-post-process-volume.png
+++ b/static/img/unreal-5/alpha-channel/level-post-process-volume.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe823aea41f4061ab14183d8ddb8eac5e09ad0598a61760747a7931a85804ec5
+size 335613

--- a/static/img/unreal-5/alpha-channel/level-post-process-volume.png
+++ b/static/img/unreal-5/alpha-channel/level-post-process-volume.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe823aea41f4061ab14183d8ddb8eac5e09ad0598a61760747a7931a85804ec5
-size 335613
+oid sha256:f74c5088d236de8ccdafa546fe706f4c72b19a8a5aff94b791e2d8f51fa4299b
+size 235836

--- a/static/img/unreal-5/alpha-channel/material-graph-component-mask-one-minus.png
+++ b/static/img/unreal-5/alpha-channel/material-graph-component-mask-one-minus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:833aa84fb1588668044269111e656077dcfccc714d62a624f0f1136eec1cafef
+size 271272

--- a/static/img/unreal-5/alpha-channel/material-graph-component-mask-one-minus.png
+++ b/static/img/unreal-5/alpha-channel/material-graph-component-mask-one-minus.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:833aa84fb1588668044269111e656077dcfccc714d62a624f0f1136eec1cafef
-size 271272
+oid sha256:0b7c649dd3bbbb14fa3a3ce4d32de9cc035a1c1d334aefffd81db4d4a9351263
+size 257550

--- a/static/img/unreal-5/alpha-channel/material-graph-new-scene-texture.png
+++ b/static/img/unreal-5/alpha-channel/material-graph-new-scene-texture.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0c4518f444218f78e2b2472c613e17f9cda46b8141d61183d5d2a731d5959e7
+size 162567

--- a/static/img/unreal-5/alpha-channel/material-graph-output-alpha.png
+++ b/static/img/unreal-5/alpha-channel/material-graph-output-alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f77f63c0c6d3c91e38603a7410d2500754d3964f5804ed8a1ff98fcbe6ab0149
+size 130078

--- a/static/img/unreal-5/alpha-channel/material-graph-post-process-material-2.png
+++ b/static/img/unreal-5/alpha-channel/material-graph-post-process-material-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c17357fac02311dc5cda61a9ba53520819a617dd93ec41d1832b3437b051d094
+size 33855

--- a/static/img/unreal-5/alpha-channel/material-graph-post-process-material.png
+++ b/static/img/unreal-5/alpha-channel/material-graph-post-process-material.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02137a81a8a4e609beb6d10f5faa23ac9a082f2b551cf865f799c3e62cd7feea
-size 248298
+oid sha256:a06c501db094758afc37f71d48bf2ef050a95f314b8525b8fd087b65318b3ea1
+size 248943

--- a/static/img/unreal-5/alpha-channel/material-graph-post-process-material.png
+++ b/static/img/unreal-5/alpha-channel/material-graph-post-process-material.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02137a81a8a4e609beb6d10f5faa23ac9a082f2b551cf865f799c3e62cd7feea
+size 248298

--- a/static/img/unreal-5/alpha-channel/post-process-volume-infinite-extent.png
+++ b/static/img/unreal-5/alpha-channel/post-process-volume-infinite-extent.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc57cad833d1f5a8923a0d7c39af0632ac07ff43485552126ad7b6582ad74a7e
+size 34060

--- a/static/img/unreal-5/alpha-channel/window-enable-content-browser.png
+++ b/static/img/unreal-5/alpha-channel/window-enable-content-browser.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:157cb129c37f38f3b18024c10d086953c7df4327997996abdffe88302ef4eb58
-size 748162

--- a/static/img/unreal-5/alpha-channel/window-enable-content-browser.png
+++ b/static/img/unreal-5/alpha-channel/window-enable-content-browser.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:157cb129c37f38f3b18024c10d086953c7df4327997996abdffe88302ef4eb58
+size 748162


### PR DESCRIPTION
The base Unreal 5 Remote Render capabilities do not include a proper alpha channel. This is a limitation of Unreal Engine, specifically. This can be corrected with post-processing.