### PR TITLE
Replace 'Remote Render' with Remote Rendering

### DIFF
--- a/docs/guides/remote-rendering/_category_.json
+++ b/docs/guides/remote-rendering/_category_.json
@@ -1,9 +1,9 @@
 {
-  "label": "Remote Render",
+  "label": "Remote Rendering",
   "position": 3,
   "collapsed": true,
    "link": {
     "type": "doc",
-    "id": "remote-render-overview"
+    "id": "remote-rendering-overview"
   }
 }

--- a/docs/guides/remote-rendering/remote-rendering-service.md
+++ b/docs/guides/remote-rendering/remote-rendering-service.md
@@ -1,7 +1,7 @@
 ---
-id: remote-render
-title: Remote Render
-sidebar_label: Remote Render Getting Started
+id: remote-rendering
+title: Remote Rendering
+sidebar_label: Remote Rendering Getting Started
 sidebar_position: 2
 date: 03/13/2023
 tags: [Render, Servers, Remote]
@@ -40,9 +40,9 @@ Magic Leap Remote Render is a first-party tool, created by Magic Leap, designed 
 
 ### Installing Magic Leap Remote Rendering
 
-1. Download the Magic Leap Remote Render package from the Package Manager within the Magic Leap Hub.
+1. Download the Magic Leap Remote Rendering package from the Package Manager within the Magic Leap Hub.
 2. Enable Wifi Bridge in the “Device Bridge”
-3. After installing **Magic Leap Remote Render**, the Hub will automatically update to display a Remote Render
+3. After installing **Magic Leap Remote Rendering**, the Hub will automatically update to display a Remote Rendering
 tile on the home screen. (If you don't see Remote Rendering at first, restart The Hub.)
 4. Click **Launch** on the Remote Rendering (Preview) tile from the Magic Leap Hub home screen.
 
@@ -54,7 +54,7 @@ tile on the home screen. (If you don't see Remote Rendering at first, restart Th
 
 6. Click the **Start Remote Render** button.
 
-![Start Remote Render Button](/img/remote-rendering/remote-rendering-ml-hub-button.png)
+![Start Remote Rendering Button](/img/remote-rendering/remote-rendering-ml-hub-button.png)
 
 7. Put on the Magic Leap 2
 8. Launch the **Remote Viewer** application
@@ -63,4 +63,4 @@ tile on the home screen. (If you don't see Remote Rendering at first, restart Th
 
 ## Prevent feedback noise when combined with Device Streaming
 
-The Remote Render functionality can be used in combination with Device Stream to preview and save what the user sees, however this may cause some audio feedback noise because the audio produced on the host is sent to the device and then back to the host by Device Stream. **To prevent audio loopback noise,** lower the volume of the Device Stream live preview before starting Remote Render.
+The Remote Rendering functionality can be used in combination with Device Stream to preview and save what the user sees, however this may cause some audio feedback noise because the audio produced on the host is sent to the device and then back to the host by Device Stream. **To prevent audio loopback noise,** lower the volume of the Device Stream live preview before starting Remote Rendering.

--- a/docs/guides/remote-rendering/remote-rendering.md
+++ b/docs/guides/remote-rendering/remote-rendering.md
@@ -1,6 +1,6 @@
 ---
-id: remote-render-overview
-title: Remote Render Overview
+id: remote-rendering-overview
+title: Remote Rendering Overview
 date: 04/19/2023
 sidebar_position: 0
 tags: [Rendering, Servers, Unreal, UE, Remote]
@@ -11,14 +11,14 @@ import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 :::caution
-**Currently, Remote Render can only be performed using Windows.**
+**Currently, Remote Rendering can only be performed using Windows.**
 :::
 
-Remote Render empowers users to enjoy interactive content with advanced graphics
+Remote Rendering empowers users to enjoy interactive content with advanced graphics
 qualities, and allows enterprise customers to reuse existing 3D assets without modification,
 compression, or decimation.
 
-Using Remote Render allows smooth integration with existing 3D workflows and applications
+Using Remote Rendering allows smooth integration with existing 3D workflows and applications
 such as Unreal Engine, Omniverse, and more.
 
 ## Resources

--- a/docs/guides/remote-rendering/unreal-engine-5.md
+++ b/docs/guides/remote-rendering/unreal-engine-5.md
@@ -1,23 +1,23 @@
 ---
 id: remote-render-unreal-engine-5
-title: Remote Render with Unreal Engine 5
+title: Remote Rendering with Unreal Engine 5
 sidebar_label: Unreal Engine 5
 sidebar_position: 2
-description: Remote Render with Unreal Engine 5.
+description: Remote Rendering with Unreal Engine 5.
 date: 05/01/2023
 tags: [Rendering, Servers, Unreal, UE, Remote Render]
 keywords: [Rendering, Servers, Unreal, UE, Remote Render]
 ---
 
 :::caution Performance and Gotchas
-Performance for remote rendering is highly-dependent on the capabilities of the host machine that is running Unreal Engine. Noticeable lag may be a result of insufficient processing or GPU power.
+Performance for Remote Rendering is highly-dependent on the capabilities of the host machine that is running Unreal Engine. Noticeable lag may be a result of insufficient processing or GPU power.
 
 In the future, an official plugin will provide more accurate mappings for Controller input.
 :::
 
 ## Prerequisite
 
-[Remote Render Setup Instructions with the Remote Render Service](/docs/guides/remote-render/remote-render).
+[Remote Rendering Setup Instructions with the Remote Rendering Service](/docs/guides/remote-render/remote-render).
 
 ## Setup
 
@@ -26,7 +26,7 @@ In the future, an official plugin will provide more accurate mappings for Contro
 ![Project Browser](/img/unreal-5/project-browser.png)
 
 :::info
-It is recommended to start the Remote Render service ahead of time. But, if it’s not running yet, the Remote Render service will be started automatically.
+It is recommended to start the Remote Rendering service ahead of time. But, if it’s not running yet, the Remote Rendering service will be started automatically.
 :::
 
 1. Enable **OpenXR**
@@ -60,7 +60,7 @@ Vulkan is the main supported graphics API for Magic Remote Rendering. Support fo
 
 ### Alpha Channel in Unreal Engine 5
 
-Magic Leap's Remote Render now supports alpha channels, which provides the user with segmented dimming and higher quality capture.
+Magic Leap's Remote Rendering now supports alpha channels, which provides the user with segmented dimming and higher quality capture.
 
 In order to take advantage of this feature in Unreal Engine OpenXR applications, you must first enable and control the output of the alpha channel.
 
@@ -72,7 +72,7 @@ Go to **Project Settings** -> **Rendering** -> **Postprocessing** and set **Enab
 
 The alpha channel as exposed by Unreal Engine will not be enough for alpha blend layers in OpenXR, this is entirely due to the fact that the alpha output is inverted.
 
-In order to correct this you will have to create a post-processing material that inverts the value of the alpha channel before it's submitted to the Remote Renderer.
+In order to correct this you will have to create a post-processing material that inverts the value of the alpha channel before it's submitted to the Remote Rendering service.
 
 Go to **Window** and enable the **Content Browser**. From the **Content Browser**, add a new material in the desired directory.
 


### PR DESCRIPTION
<img width="1292" alt="Screen Shot 2023-05-05 at 4 05 45 PM" src="https://user-images.githubusercontent.com/6310006/236582719-9c2bce6d-22e6-4a90-b0ed-c74f8c16453f.png">

Branding has landed on **Remote Render**.