### PR TITLE
Update release notes Overview page to add September 23

### DIFF
--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -13,6 +13,24 @@ import VersionMatrix from '/docs/releases/_version-matrix.md';
 
 Wondering what's new in the latest software releases? Check out our release notes to learn about the latest new features and enhancements we've made to help you develop your Magic Leap applications.
 
+## Release 2023 September
+
+### [OS Release Notes](release-2023-september/os-release-notes/os-release-notes.md)
+
+Learn what changes were made in the latest OS release. For your device to take advantage of the latest tools and features, make sure you [flash your device](/docs/guides/device/updating-the-os/device-flashing-guide.md) with the latest OS.
+
+### [Native SDK Release Notes](release-2023-september/sdk-release-notes.md)
+
+View the SDK release notes to see what changes were made to the Magic Leap SDK.
+
+### [Unity SDK Release Notes](release-2023-september/unity-sdk-release-notes.md)
+
+View the SDK release notes to see what changes were made to the Magic Leap SDK.
+
+### [Soundfield Audio for Unreal Engine](release-2023-september/unreal-soundfield-release-notes.md)
+
+View the SDK release notes to see the features of this initial release.
+
 ## Release 2023 August
 
 ### [OS Release Notes](release-2023-august/os-release-notes/os-release-notes.md)

--- a/docs/releases/release-2023-september/os-release-notes/os-release-notes.md
+++ b/docs/releases/release-2023-september/os-release-notes/os-release-notes.md
@@ -40,7 +40,7 @@ Version update of the localization and mapping services to version 2.0.1
 
 ### Fixed Depth Camera Short Range Exposure Control
 
-The ML C-API for the depth camera had a bug where if the user programmed the camera to run in short range mode with a specific exposure, frames returned by the API could be generated using the wrong exposure value. As of Sprint 27, when programming the depth camera to run in short range mode with a specific exposure value, short range frames returned by the API are correctly generated using the programmed exposure.
+The ML C-API for the depth camera had a bug where if the user programmed the camera to run in short range mode with a specific exposure, frames returned by the API could be generated using the wrong exposure value. As of 1.4.0-dev2, when programming the depth camera to run in short range mode with a specific exposure value, short range frames returned by the API are correctly generated using the programmed exposure.
 
 ## Known Issues
 


### PR DESCRIPTION
Add missing information on the Overview page and replace sprint naming